### PR TITLE
Scraping defaults - added more ciphers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ const SCRAPING_DEFAULT_OPTIONS = {
     // We want to take some action after this.
     throwHttpErrors: false,
     // Node js uses different TLS ciphers by default.
-    ciphers: getCiphersBasedOnNode(),
+    // This is very useful at fighting protection, but can on some websites cause TLS errors.
+    ciphers: "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256",
     // We need to have browser-like headers to blend in.
     useHeaderGenerator: true,
     // Got has infinite timeout by default. In scraping we have to count with bad proxies. Without custom timeout it would just hang.

--- a/src/scraping-defaults.js
+++ b/src/scraping-defaults.js
@@ -28,7 +28,7 @@ function getCiphersBasedOnNode() {
     if (nodeVersion < 12) {
         return;
     }
-    return 'TLS_AES_256_GCM_SHA384';
+    return 'TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256';
 }
 
 module.exports = {

--- a/test/scraping-defaults.test.js
+++ b/test/scraping-defaults.test.js
@@ -36,7 +36,7 @@ describe('Scraping defaults', () => {
         if (nodeVersion < 12) {
             expect(SCRAPING_DEFAULT_OPTIONS.ciphers).toBe(undefined);
         } else {
-            expect(SCRAPING_DEFAULT_OPTIONS.ciphers).toBe('TLS_AES_256_GCM_SHA384');
+            expect(SCRAPING_DEFAULT_OPTIONS.ciphers).toBe('TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256');
         }
     });
 });


### PR DESCRIPTION
Based on the node docs. There are three default TLS 1.3 ciphers used.
```
There are only 5 TLSv1.3 cipher suites:

'TLS_AES_256_GCM_SHA384'
'TLS_CHACHA20_POLY1305_SHA256'
'TLS_AES_128_GCM_SHA256'
'TLS_AES_128_CCM_SHA256'
'TLS_AES_128_CCM_8_SHA256'
The first 3 are enabled by default. The last 2 CCM-based suites are supported by TLSv1.3 because they may be more performant on constrained systems, but they are not enabled by default since they offer less security.
```

This should just ensure that the `TLS_AES_256_GCM_SHA384` is used first.

closes #10 