### PR TITLE
Add `TransfomHeadersAgent`

### DIFF
--- a/src/agent/transform-headers-agent.js
+++ b/src/agent/transform-headers-agent.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-underscore-dangle */
+const http = require('http');
+const WrappedAgent = require('./wrapped-agent');
+
+const { _storeHeader } = http.OutgoingMessage.prototype;
+
+class TransformHeadersAgent extends WrappedAgent {
+    transformRequest(request) {
+        const headers = {};
+        const hasConnection = request.hasHeader('connection');
+        const hasContentLength = request.hasHeader('content-length');
+        const hasTransferEncoding = request.hasHeader('transfer-encoding');
+        const hasTrailer = request.hasHeader('trailer');
+        const keys = request.getHeaderNames();
+
+        for (const key of keys) {
+            headers[key] = request.getHeader(key);
+            request.removeHeader(key);
+        }
+
+        if (!hasConnection) {
+            const shouldSendKeepAlive = request.shouldKeepAlive && (hasContentLength || request.useChunkedEncodingByDefault || request.agent);
+            if (shouldSendKeepAlive) {
+                headers[this.transformHeader('connection')] = 'keep-alive';
+            } else {
+                headers[this.transformHeader('connection')] = 'close';
+            }
+        }
+
+        if (!hasContentLength && !hasTransferEncoding) {
+            if (!hasTrailer && !request._removedContLen && typeof request._contentLength === 'number') {
+                headers[this.transformHeader('content-length')] = request._contentLength;
+            } else if (!request._removedTE) {
+                headers[this.transformHeader('transfer-encoding')] = 'chunked';
+            }
+        }
+
+        const sorted = Object.keys(headers)/* .sort(this.sort) */;
+
+        for (const key of sorted) {
+            request.setHeader(this.transformHeader(key), headers[key]);
+        }
+    }
+
+    addRequest(request, options) {
+        request._storeHeader = (...args) => {
+            this.transformRequest(request);
+
+            return _storeHeader.call(request, ...args);
+        };
+
+        return super.addRequest(request, options);
+    }
+
+    transformHeader(header) {
+        return header.split('-').map((part) => {
+            return part[0].toUpperCase() + part.slice(1);
+        }).join('-');
+    }
+
+    sort(a, b) {
+        const { sortedHeaders } = this;
+
+        const rawA = sortedHeaders.indexOf(a);
+        const rawB = sortedHeaders.indexOf(b);
+        const indexA = rawA === -1 ? Number.POSITIVE_INFINITY : rawA;
+        const indexB = rawB === -1 ? Number.POSITIVE_INFINITY : rawB;
+
+        if (indexA < indexB) {
+            return -1;
+        }
+
+        if (indexA > indexB) {
+            return 1;
+        }
+
+        return 0;
+    }
+}
+
+module.exports = TransformHeadersAgent;

--- a/src/agent/wrapped-agent.js
+++ b/src/agent/wrapped-agent.js
@@ -1,0 +1,35 @@
+/**
+ * @description Wraps an existing Agent instance,
+ *              so there's no need to replace `agent.addRequest`.
+ */
+class WrappedAgent {
+    constructor(agent) {
+        this.agent = agent;
+    }
+
+    addRequest(request, options) {
+        return this.agent.addRequest(request, options);
+    }
+
+    get keepAlive() {
+        return this.agent.keepAlive;
+    }
+
+    get maxSockets() {
+        return this.agent.maxSockets;
+    }
+
+    get options() {
+        return this.agent.options;
+    }
+
+    get defaultPort() {
+        return this.agent.defaultPort;
+    }
+
+    get protocol() {
+        return this.agent.protocol;
+    }
+}
+
+module.exports = WrappedAgent;

--- a/src/hooks/proxy.js
+++ b/src/hooks/proxy.js
@@ -2,6 +2,7 @@ const http2 = require('http2-wrapper');
 const HttpsProxyAgent = require('https-proxy-agent');
 const HttpProxyAgent = require('http-proxy-agent');
 const httpResolver = require('../http-resolver');
+const TransformHeadersAgent = require('../agent/transform-headers-agent');
 
 const {
     HttpOverHttp2,
@@ -83,21 +84,21 @@ async function getAgents(parsedProxyUrl, rejectUnauthorized) {
 
         if (proxyIsHttp2) {
             agent = {
-                http: new HttpOverHttp2(proxy),
-                https: new HttpsOverHttp2(proxy),
+                http: new TransformHeadersAgent(new HttpOverHttp2(proxy)),
+                https: new TransformHeadersAgent(new HttpsOverHttp2(proxy)),
                 http2: new Http2OverHttp2(proxy),
             };
         } else {
             agent = {
-                http: new HttpsProxyAgent(proxyUrl.href),
-                https: new HttpsProxyAgent(proxyUrl.href),
+                http: new TransformHeadersAgent(new HttpsProxyAgent(proxyUrl.href)),
+                https: new TransformHeadersAgent(new HttpsProxyAgent(proxyUrl.href)),
                 http2: new Http2OverHttps(proxy),
             };
         }
     } else {
         agent = {
-            http: new HttpProxyAgent(proxyUrl.href),
-            https: new HttpsProxyAgent(proxyUrl.href),
+            http: new TransformHeadersAgent(new HttpProxyAgent(proxyUrl.href)),
+            https: new TransformHeadersAgent(new HttpsProxyAgent(proxyUrl.href)),
             http2: new Http2OverHttp(proxy),
         };
     }

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -4,6 +4,7 @@ const HttpProxyAgent = require('http-proxy-agent');
 
 const { proxyHook } = require('../src/hooks/proxy');
 const httpResolver = require('../src/http-resolver');
+const TransformHeadersAgent = require('../src/agent/transform-headers-agent');
 
 const {
     HttpOverHttp2,
@@ -59,7 +60,8 @@ describe('Proxy', () => {
             await proxyHook(options);
 
             const { agent } = options;
-            expect(agent.http).toBeInstanceOf(HttpProxyAgent);
+            expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
+            expect(agent.http.agent).toBeInstanceOf(HttpProxyAgent);
         });
 
         test('should support https request over http proxy', async () => {
@@ -70,7 +72,8 @@ describe('Proxy', () => {
             await proxyHook(options);
 
             const { agent } = options;
-            expect(agent.https).toBeInstanceOf(HttpsProxyAgent);
+            expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
+            expect(agent.https.agent).toBeInstanceOf(HttpsProxyAgent);
         });
 
         test('should support http2 request over http proxy', async () => {
@@ -92,7 +95,8 @@ describe('Proxy', () => {
             await proxyHook(options);
 
             const { agent } = options;
-            expect(agent.http).toBeInstanceOf(HttpsProxyAgent);
+            expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
+            expect(agent.http.agent).toBeInstanceOf(HttpsProxyAgent);
         });
 
         test('should support https request over https proxy', async () => {
@@ -103,7 +107,8 @@ describe('Proxy', () => {
             await proxyHook(options);
 
             const { agent } = options;
-            expect(agent.https).toBeInstanceOf(HttpsProxyAgent);
+            expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
+            expect(agent.https.agent).toBeInstanceOf(HttpsProxyAgent);
         });
 
         test('should support http2 request over https proxy', async () => {
@@ -125,7 +130,8 @@ describe('Proxy', () => {
             await proxyHook(options);
 
             const { agent } = options;
-            expect(agent.http).toBeInstanceOf(HttpOverHttp2);
+            expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
+            expect(agent.http.agent).toBeInstanceOf(HttpOverHttp2);
         });
 
         test('should support https request over http2 proxy', async () => {
@@ -136,7 +142,8 @@ describe('Proxy', () => {
             await proxyHook(options);
 
             const { agent } = options;
-            expect(agent.https).toBeInstanceOf(HttpsOverHttp2);
+            expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
+            expect(agent.https.agent).toBeInstanceOf(HttpsOverHttp2);
         });
 
         test('should support http2 request over http2 proxy', async () => {


### PR DESCRIPTION
- [x] Fixes an issue where

https://github.com/apify/got-scraping/blob/e774400551ff9eb5544149cb20a4b340f3631b4c/src/hooks/browser-headers.js#L23

returns a `lower-case` header for HTTP/1.1 requests. Easily reproducible via:

replacing the above with

```js
    let generatedHeaders;
    do {
        generatedHeaders = headerGenerator.getHeaders(mergedHeaderGeneratorOptions);
    } while (!generatedHeaders['user-agent']);
```

and do `test.only` with

https://github.com/apify/got-scraping/blob/e774400551ff9eb5544149cb20a4b340f3631b4c/test/main.test.js#L260

- [x] Allows header sorting (not integrated yet)