### PR TITLE
Migrate to `hpagent`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "got-scraping",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "HTTP client made for scraping based on got.",
     "main": "src/index.js",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
     "dependencies": {
         "got-cjs": "12.0.0-beta.3",
         "header-generator": "^1.1.0-beta.1",
-        "http-proxy-agent": "^4.0.1",
+        "hpagent": "^0.1.2",
         "http2-wrapper": "^2.1.2",
-        "https-proxy-agent": "^5.0.0",
         "ow": "^0.23.0",
         "quick-lru": "^5.1.1"
     },

--- a/src/hooks/proxy.js
+++ b/src/hooks/proxy.js
@@ -1,6 +1,8 @@
 const http2 = require('http2-wrapper');
-const HttpsProxyAgent = require('https-proxy-agent');
-const HttpProxyAgent = require('http-proxy-agent');
+const {
+    HttpsProxyAgent,
+    HttpProxyAgent,
+} = require('hpagent');
 const QuickLRU = require('quick-lru');
 const TransformHeadersAgent = require('../agent/transform-headers-agent');
 
@@ -122,15 +124,15 @@ async function getAgents(parsedProxyUrl, rejectUnauthorized) {
             };
         } else {
             agent = {
-                http: fixAgent(new HttpsProxyAgent(proxyUrl.href)),
-                https: fixAgent(new HttpsProxyAgent(proxyUrl.href)),
+                http: fixAgent(new HttpsProxyAgent({ proxy: proxyUrl })),
+                https: fixAgent(new HttpsProxyAgent({ proxy: proxyUrl })),
                 http2: new Http2OverHttps(proxy),
             };
         }
     } else {
         agent = {
-            http: fixAgent(new HttpProxyAgent(proxyUrl.href)),
-            https: fixAgent(new HttpsProxyAgent(proxyUrl.href)),
+            http: fixAgent(new HttpProxyAgent({ proxy: proxyUrl })),
+            https: fixAgent(new HttpsProxyAgent({ proxy: proxyUrl })),
             http2: new Http2OverHttp(proxy),
         };
     }

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -1,6 +1,8 @@
 const http2 = require('http2-wrapper');
-const HttpsProxyAgent = require('https-proxy-agent');
-const HttpProxyAgent = require('http-proxy-agent');
+const {
+    HttpsProxyAgent,
+    HttpProxyAgent
+} = require('hpagent');
 
 const { proxyHook, agentCache } = require('../src/hooks/proxy');
 const TransformHeadersAgent = require('../src/agent/transform-headers-agent');


### PR DESCRIPTION
This fixes issues with [`agent-base`](https://github.com/TooTallNate/node-agent-base) and [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent/blob/master/src/agent.ts)