### PR TITLE
Use own proxy agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
     "dependencies": {
         "got-cjs": "12.0.0-beta.4",
         "header-generator": "^1.1.0",
-        "http-proxy-agent": "^4.0.1",
+        "hpagent": "^0.1.2",
         "http2-wrapper": "^2.1.3",
-        "https-proxy-agent": "^5.0.0",
         "ow": "^0.23.0",
         "quick-lru": "^5.1.1"
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "dependencies": {
         "got-cjs": "12.0.0-beta.4",
         "header-generator": "^1.1.0",
-        "hpagent": "^0.1.2",
         "http2-wrapper": "^2.1.3",
         "ow": "^0.23.0",
         "quick-lru": "^5.1.1"

--- a/src/agent/h1-proxy-agent.ts
+++ b/src/agent/h1-proxy-agent.ts
@@ -1,0 +1,146 @@
+/* eslint-disable max-classes-per-file */
+import { URL } from 'url';
+import tls, { ConnectionOptions } from 'tls';
+import http, { ClientRequest, ClientRequestArgs } from 'http';
+import https from 'https';
+
+interface AgentOptions extends http.AgentOptions {
+    proxy: string | URL;
+    disableConnect?: boolean;
+}
+
+const initialize = (self: http.Agent & { proxy: URL }, options: AgentOptions) => {
+    self.proxy = typeof options.proxy === 'string' ? new URL(options.proxy) : options.proxy;
+};
+
+const getBasic = (url: URL): string => {
+    let basic = '';
+    if (url.username || url.password) {
+        const username = decodeURIComponent(url.username);
+        const password = decodeURIComponent(url.password);
+
+        basic = Buffer.from(`${username}:${password}`).toString('base64');
+
+        return `Basic ${basic}`;
+    }
+
+    return basic;
+};
+
+export class HttpRegularProxyAgent extends http.Agent {
+    proxy!: URL;
+
+    constructor(options: AgentOptions) {
+        super(options);
+
+        initialize(this, options);
+    }
+
+    addRequest(request: ClientRequest, options: ClientRequestArgs): void {
+        if (options.socketPath) {
+            // @ts-expect-error @types/node is missing types
+            super.addRequest(request, options);
+            return;
+        }
+
+        const hostport = `${options.host}:${options.port}`;
+        const url = new URL(`${request.protocol}//${hostport}${request.path}`);
+
+        options = {
+            ...options,
+            host: this.proxy.hostname,
+            port: this.proxy.port,
+        };
+
+        request.path = url.href;
+
+        const basic = getBasic(this.proxy);
+        if (basic) {
+            request.setHeader('proxy-authorization', basic);
+        }
+
+        // @ts-expect-error @types/node is missing types
+        super.addRequest(request, options);
+    }
+}
+
+export class HttpProxyAgent extends http.Agent {
+    proxy!: URL;
+
+    constructor(options: AgentOptions) {
+        super(options);
+
+        initialize(this, options);
+    }
+
+    createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
+        if (options.path) {
+            // @ts-expect-error @types/node is missing types
+            super.createConnection(options, callback);
+            return;
+        }
+
+        const fn = this.proxy.protocol === 'https:' ? https.request : http.request;
+
+        const hostport = `${options.host}:${options.port}`;
+
+        const headers: Record<string, string> = {
+            host: hostport,
+        };
+
+        const basic = getBasic(this.proxy);
+        if (basic) {
+            headers['proxy-authorization'] = basic;
+            headers.authorization = basic;
+        }
+
+        const connectRequest = fn(this.proxy, {
+            method: 'CONNECT',
+            headers,
+            path: hostport,
+            agent: false,
+
+            rejectUnauthorized: false,
+        });
+
+        connectRequest.once('connect', (response, socket, head) => {
+            if (head.length > 0 || response.statusCode !== 200) {
+                socket.destroy();
+
+                const error = new Error(`The proxy responded with ${response.statusCode}: ${head.toString()}`);
+                callback(error);
+                return;
+            }
+
+            if ((options as any).protocol === 'https:') {
+                callback(undefined, tls.connect({
+                    ...options,
+                    socket,
+                }));
+                return;
+            }
+
+            callback(undefined, socket);
+        });
+
+        connectRequest.once('error', (error) => {
+            callback(error);
+        });
+
+        connectRequest.end();
+    }
+}
+
+export class HttpsProxyAgent extends https.Agent {
+    proxy!: URL;
+
+    constructor(options: AgentOptions) {
+        super(options);
+
+        initialize(this, options);
+    }
+
+    createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
+        HttpProxyAgent.prototype.createConnection.call(this, options, callback);
+    }
+}

--- a/src/hooks/proxy.ts
+++ b/src/hooks/proxy.ts
@@ -2,8 +2,7 @@ import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import { URL } from 'url';
 import { proxies, auto } from 'http2-wrapper';
-import { HttpsProxyAgent } from 'https-proxy-agent';
-import { HttpProxyAgent } from 'http-proxy-agent';
+import { HttpsProxyAgent, HttpProxyAgent } from 'hpagent';
 import QuickLRU from 'quick-lru';
 import { Options } from 'got-cjs';
 import { TransformHeadersAgent } from '../agent/transform-headers-agent';
@@ -111,15 +110,15 @@ async function getAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean) {
             };
         } else {
             agent = {
-                http: fixAgent(new HttpsProxyAgent(proxyUrl.href)),
-                https: fixAgent(new HttpsProxyAgent(proxyUrl.href)),
+                http: fixAgent(new HttpsProxyAgent({ proxy: proxyUrl })),
+                https: fixAgent(new HttpsProxyAgent({ proxy: proxyUrl })),
                 http2: new Http2OverHttps(proxy),
             };
         }
     } else {
         agent = {
-            http: fixAgent(new HttpProxyAgent(proxyUrl.href)),
-            https: fixAgent(new HttpsProxyAgent(proxyUrl.href)),
+            http: fixAgent(new HttpProxyAgent({ proxy: proxyUrl })),
+            https: fixAgent(new HttpsProxyAgent({ proxy: proxyUrl })),
             http2: new Http2OverHttp(proxy),
         };
     }

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -2,8 +2,8 @@ import { URL } from 'url';
 import http2 from 'http2-wrapper';
 import {
     HttpsProxyAgent,
-    HttpProxyAgent,
-} from 'hpagent';
+    HttpRegularProxyAgent,
+} from '../src/agent/h1-proxy-agent';
 
 import { proxyHook, agentCache } from '../src/hooks/proxy';
 import { TransformHeadersAgent } from '../src/agent/transform-headers-agent';
@@ -64,7 +64,7 @@ describe('Proxy', () => {
 
             const { agent } = options;
             expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
-            expect((agent.http as any).agent).toBeInstanceOf(HttpProxyAgent);
+            expect((agent.http as any).agent).toBeInstanceOf(HttpRegularProxyAgent);
         });
 
         test('should support https request over http proxy', async () => {
@@ -97,7 +97,7 @@ describe('Proxy', () => {
 
             const { agent } = options;
             expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
-            expect((agent.http as any).agent).toBeInstanceOf(HttpsProxyAgent);
+            expect((agent.http as any).agent).toBeInstanceOf(HttpRegularProxyAgent);
         });
 
         test('should support https request over https proxy', async () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,7 +1,9 @@
 import { URL } from 'url';
 import http2 from 'http2-wrapper';
-import { HttpsProxyAgent } from 'https-proxy-agent';
-import { HttpProxyAgent } from 'http-proxy-agent';
+import {
+    HttpsProxyAgent,
+    HttpProxyAgent,
+} from 'hpagent';
 
 import { proxyHook, agentCache } from '../src/hooks/proxy';
 import { TransformHeadersAgent } from '../src/agent/transform-headers-agent';


### PR DESCRIPTION
No promise usage = no unhandled rejections + no uncaught exceptions ;) Drop-in replacement for `hpagent`.

I had to revert `hpagent` on `got-scraping@2` because some proxies don't support `CONNECT` protocol, they're just usual web proxies.

#### TODO:

- [ ] test with `apify-js`