### PR TITLE
fix: retry without decompress

### DIFF
--- a/src/hooks/fix-decompress.ts
+++ b/src/hooks/fix-decompress.ts
@@ -1,7 +1,27 @@
-import { RequestError } from 'got-cjs';
+import { URL } from 'url';
+import { RequestError, Options } from 'got-cjs';
+
+const toSkip: string[] = [];
+
+export function shouldDecompress(options: Options): void {
+    if (options.decompress) {
+        const url = options.url as URL;
+
+        if (toSkip.includes(url.origin)) {
+            options.decompress = false;
+        }
+    }
+}
 
 export function fixDecompress(error: RequestError): void {
     if (error.code === 'Z_DATA_ERROR') {
         error.options.decompress = false;
+
+        const url = error.options.url as URL;
+        toSkip.push(url.origin);
+
+        if (toSkip.length > 1000) {
+            toSkip.shift();
+        }
     }
 }

--- a/src/hooks/fix-decompress.ts
+++ b/src/hooks/fix-decompress.ts
@@ -1,0 +1,7 @@
+import { RequestError } from 'got-cjs';
+
+export function fixDecompress(error: RequestError): void {
+    if (error.code === 'Z_DATA_ERROR') {
+        error.options.decompress = false;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { http2Hook } from './hooks/http2';
 import { insecureParserHook } from './hooks/insecure-parser';
 import { tlsHook } from './hooks/tls';
 import { sessionDataHook } from './hooks/storage';
+import { fixDecompress } from './hooks/fix-decompress';
 
 const gotScraping = gotCjs.extend({
     mutableDefaults: true,
@@ -29,7 +30,6 @@ const gotScraping = gotCjs.extend({
     // Don't fail on 404
     throwHttpErrors: false,
     timeout: { request: 60000 },
-    retry: { limit: 0 },
     headers: {
         'user-agent': undefined,
     },
@@ -55,6 +55,18 @@ const gotScraping = gotCjs.extend({
             browserHeadersHook,
             tlsHook,
         ],
+        beforeRetry: [
+            fixDecompress,
+        ],
+    },
+    retry: {
+        calculateDelay: ({ error, attemptCount }) => {
+            if (error.code === 'Z_DATA_ERROR' && attemptCount === 0) {
+                return 1;
+            }
+
+            return 0;
+        },
     },
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { http2Hook } from './hooks/http2';
 import { insecureParserHook } from './hooks/insecure-parser';
 import { tlsHook } from './hooks/tls';
 import { sessionDataHook } from './hooks/storage';
-import { fixDecompress } from './hooks/fix-decompress';
+import { fixDecompress, shouldDecompress } from './hooks/fix-decompress';
 
 const gotScraping = gotCjs.extend({
     mutableDefaults: true,
@@ -54,6 +54,7 @@ const gotScraping = gotCjs.extend({
             proxyHook,
             browserHeadersHook,
             tlsHook,
+            shouldDecompress,
         ],
         beforeRetry: [
             fixDecompress,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ const gotScraping = gotCjs.extend({
     },
     retry: {
         calculateDelay: ({ error, attemptCount }) => {
-            if (error.code === 'Z_DATA_ERROR' && attemptCount === 0) {
+            if (error.code === 'Z_DATA_ERROR' && error.options.method === 'GET' && attemptCount === 0) {
                 return 1;
             }
 


### PR DESCRIPTION
This works however if some entire website is incorrectly performing compression, then all requests would end up duplicated. I think we could do some caching in this regard (to know when to disable decompress)?

TODO: tests