### PR TITLE
fix: be more lenient when decompressing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "got-cjs": "12.0.1",
         "header-generator": "^1.1.1",
         "http2-wrapper": "^2.1.4",
+        "mimic-response": "^3.1.0",
         "ow": "^0.23.0",
         "quick-lru": "^5.1.1",
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "got-scraping",
-    "version": "3.2.7",
+    "version": "3.2.8",
     "description": "HTTP client made for scraping based on got.",
     "main": "dist/index.js",
     "engines": {

--- a/src/hooks/browser-headers.ts
+++ b/src/hooks/browser-headers.ts
@@ -99,6 +99,14 @@ export async function browserHeadersHook(options: Options): Promise<void> {
         });
     }
 
+    if (!options.decompress) {
+        for (const key of Object.keys(generatedHeaders)) {
+            if (key.toLowerCase() === 'accept-encoding') {
+                delete generatedHeaders[key];
+            }
+        }
+    }
+
     // TODO: Use `options.merge({headers: generatedHeaders})` instead
     options.headers = mergeHeaders(generatedHeaders, options.headers as Record<string, string>);
 }

--- a/src/hooks/fix-decompress.ts
+++ b/src/hooks/fix-decompress.ts
@@ -5,7 +5,7 @@ import { PassThrough, Transform } from 'stream';
 import mimicResponse from 'mimic-response';
 
 const onResponse = (response: IncomingMessage, propagate: (fixedResponse: IncomingMessage) => void) => {
-    const encoding = response.headers['content-encoding'];
+    const encoding = response.headers['content-encoding']?.toLowerCase();
 
     // Append empty chunk.
     const zlibOptions = {
@@ -66,11 +66,13 @@ export const fixDecompress: HandlerFunction = (options, next) => {
             if (event === 'response') {
                 const response = args[0] as IncomingMessage;
 
+                const emitted = request.listenerCount('response') !== 0;
+
                 onResponse(response, (fixedResponse: IncomingMessage) => {
                     emit('response', fixedResponse);
                 });
 
-                return request.listenerCount('response') !== 0;
+                return emitted;
             }
 
             return emit.call(request, event, ...args);

--- a/src/hooks/fix-decompress.ts
+++ b/src/hooks/fix-decompress.ts
@@ -1,0 +1,81 @@
+import zlib from 'zlib';
+import { ClientRequest, IncomingMessage } from 'http';
+import { HandlerFunction } from 'got-cjs';
+import { PassThrough, Transform } from 'stream';
+import mimicResponse from 'mimic-response';
+
+const onResponse = (response: IncomingMessage, propagate: (fixedResponse: IncomingMessage) => void) => {
+    const encoding = response.headers['content-encoding'];
+
+    // Append empty chunk.
+    const zlibOptions = {
+        flush: zlib.constants.Z_SYNC_FLUSH,
+        finishFlush: zlib.constants.Z_SYNC_FLUSH,
+    };
+
+    const useDecompressor = (decompressor: Transform) => {
+        delete response.headers['content-encoding'];
+
+        const result = new PassThrough({
+            autoDestroy: false,
+            destroy(error, callback) {
+                response.destroy();
+
+                callback(error);
+            },
+        });
+
+        response.pipe(decompressor).pipe(result);
+
+        propagate(mimicResponse(response, result));
+    };
+
+    if (encoding === 'gzip' || encoding === 'x-gzip') {
+        useDecompressor(zlib.createGunzip(zlibOptions));
+    } else if (encoding === 'deflate' || encoding === 'x-deflate') {
+        response.once('data', (chunk: Buffer) => {
+            response.unshift(chunk);
+
+            // See http://stackoverflow.com/questions/37519828
+            // eslint-disable-next-line no-bitwise
+            const decompressor = (chunk[0] & 0x0F) === 0x08 ? zlib.createInflate() : zlib.createInflateRaw();
+            useDecompressor(decompressor);
+        });
+    } else if (encoding === 'br') {
+        useDecompressor(zlib.createBrotliDecompress());
+    } else {
+        propagate(response);
+    }
+};
+
+export const fixDecompress: HandlerFunction = (options, next) => {
+    if (options.decompress) {
+        options.headers['accept-encoding'] = process.versions.brotli ? 'gzip, deflate, br' : 'gzip, deflate';
+        options.decompress = false;
+    } else {
+        return next(options);
+    }
+
+    const result = next(options);
+
+    // @ts-expect-error Looks like a TypeScript bug
+    result.on('request', (request: ClientRequest) => {
+        const emit = request.emit.bind(request);
+
+        request.emit = (event: string, ...args: unknown[]) => {
+            if (event === 'response') {
+                const response = args[0] as IncomingMessage;
+
+                onResponse(response, (fixedResponse: IncomingMessage) => {
+                    emit('response', fixedResponse);
+                });
+
+                return request.listenerCount('response') !== 0;
+            }
+
+            return emit.call(request, event, ...args);
+        };
+    });
+
+    return result;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,12 @@ import { http2Hook } from './hooks/http2';
 import { insecureParserHook } from './hooks/insecure-parser';
 import { tlsHook } from './hooks/tls';
 import { sessionDataHook } from './hooks/storage';
+import { fixDecompress } from './hooks/fix-decompress';
 
 const gotScraping = gotCjs.extend({
+    handlers: [
+        fixDecompress,
+    ],
     mutableDefaults: true,
     // Most of the new browsers use HTTP/2
     http2: true,

--- a/test/helpers/dummy-server.ts
+++ b/test/helpers/dummy-server.ts
@@ -1,4 +1,5 @@
 import { Server } from 'http';
+import zlib from 'zlib';
 import express, { Express } from 'express';
 import bodyParser from 'body-parser';
 
@@ -55,6 +56,11 @@ const startDummyServer = async (port = 0): Promise<Server> => {
 
     app.get('/query', (req, res) => {
         res.send(req.url.slice(req.url.indexOf('?') + 1));
+    });
+
+    app.get('/invalid-deflate', (_req, res) => {
+        res.setHeader('content-encoding', 'deflate');
+        res.send(zlib.deflateRawSync('ok'));
     });
 
     return startExpressAppPromise(app, port);

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -338,6 +338,11 @@ describe('GotScraping', () => {
         });
     });
 
+    test('is lenient on decompression', async () => {
+        const response = await gotScraping.get(`http://localhost:${port}/invalid-deflate`);
+        expect(response.body).toBe('ok');
+    });
+
     describe('same thing with streams', () => {
         test('should order headers', async () => {
             const body = await getStream(gotScraping.stream({ url: 'https://api.apify.com/v2/browser-info?rawHeaders=1' }));


### PR DESCRIPTION
Figured out even a smarter solution, overriding the `response` event 😎

Closes #63