### PR TITLE
fix: allow passing extra options like `proxyUrl` on type level

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 import https from 'https';
 
-import { got as gotCjs, Options } from 'got-cjs';
+import { Got, got as gotCjs, HTTPAlias, Options } from 'got-cjs';
 import { HeaderGenerator } from 'header-generator';
 
 import { TransformHeadersAgent } from './agent/transform-headers-agent';
@@ -16,6 +16,7 @@ import { tlsHook } from './hooks/tls';
 import { sessionDataHook } from './hooks/storage';
 import { fixDecompress } from './hooks/fix-decompress';
 import { refererHook } from './hooks/referer';
+import { ExtendedGotRequestFunction } from './types';
 
 const gotScraping = gotCjs.extend({
     handlers: [
@@ -62,7 +63,7 @@ const gotScraping = gotCjs.extend({
             refererHook,
         ],
     },
-});
+}) as Got & Record<HTTPAlias, ExtendedGotRequestFunction> & ExtendedGotRequestFunction;
 
 /**
  * Mock the `decodeURI` global for the time when Got is normalizing the URL.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,58 @@
+import { CancelableRequest, Options, Request, Response } from 'got-cjs';
+import { OptionsInit } from './context';
+
+type Except<ObjectType, KeysType extends keyof ObjectType> = Pick<ObjectType, Exclude<keyof ObjectType, KeysType>>;
+type Merge<FirstType, SecondType> = Except<FirstType, Extract<keyof FirstType, keyof SecondType>> & SecondType;
+
+export interface ExtendedGotRequestFunction {
+    (url: string | URL, options?: ExtendedOptionsOfTextResponseBody): CancelableRequest<Response<string>>;
+    <T>(url: string | URL, options?: ExtendedOptionsOfJSONResponseBody): CancelableRequest<Response<T>>;
+    (url: string | URL, options?: ExtendedOptionsOfBufferResponseBody): CancelableRequest<Response<Buffer>>;
+    (url: string | URL, options?: ExtendedOptionsOfUnknownResponseBody): CancelableRequest<Response>;
+    (options: ExtendedOptionsOfTextResponseBody): CancelableRequest<Response<string>>;
+    <T>(options: ExtendedOptionsOfJSONResponseBody): CancelableRequest<Response<T>>;
+    (options: ExtendedOptionsOfBufferResponseBody): CancelableRequest<Response<Buffer>>;
+    (options: ExtendedOptionsOfUnknownResponseBody): CancelableRequest<Response>;
+    (url: string | URL, options?: (Merge<ExtendedOptionsOfTextResponseBody, ResponseBodyOnly>)): CancelableRequest<string>;
+    <T>(url: string | URL, options?: (Merge<ExtendedOptionsOfJSONResponseBody, ResponseBodyOnly>)): CancelableRequest<T>;
+    (url: string | URL, options?: (Merge<ExtendedOptionsOfBufferResponseBody, ResponseBodyOnly>)): CancelableRequest<Buffer>;
+    (options: (Merge<ExtendedOptionsOfTextResponseBody, ResponseBodyOnly>)): CancelableRequest<string>;
+    <T>(options: (Merge<ExtendedOptionsOfJSONResponseBody, ResponseBodyOnly>)): CancelableRequest<T>;
+    (options: (Merge<ExtendedOptionsOfBufferResponseBody, ResponseBodyOnly>)): CancelableRequest<Buffer>;
+    (url: string | URL, options?: Merge<OptionsInit, {
+        isStream: true;
+    }>): Request;
+    (options: Merge<OptionsInit, {
+        isStream: true;
+    }>): Request;
+    (url: string | URL, options?: OptionsInit): CancelableRequest | Request;
+    (options: OptionsInit): CancelableRequest | Request;
+    (url: undefined, options: undefined, defaults: Options): CancelableRequest | Request;
+}
+
+export type ExtendedOptionsOfTextResponseBody = Merge<OptionsInit, {
+    isStream?: false;
+    resolveBodyOnly?: false;
+    responseType?: 'text';
+}>
+
+export type ExtendedOptionsOfJSONResponseBody = Merge<OptionsInit, {
+    isStream?: false;
+    resolveBodyOnly?: false;
+    responseType?: 'json';
+}>;
+
+export type ExtendedOptionsOfBufferResponseBody = Merge<OptionsInit, {
+    isStream?: false;
+    resolveBodyOnly?: false;
+    responseType: 'buffer';
+}>;
+
+export type ExtendedOptionsOfUnknownResponseBody = Merge<OptionsInit, {
+    isStream?: false;
+    resolveBodyOnly?: false;
+}>;
+
+export type ResponseBodyOnly = {
+    resolveBodyOnly: true;
+};


### PR DESCRIPTION
This solves an internally reported issue where using got-scraping would not include our custom options (like `proxyUrl`)