### PR TITLE
chore: use new workflow secrets, update GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,6 @@ on:
     pull_request:
 
 jobs:
-    # NPM install is done in a separate job and cached to speed up the following jobs.
     build_and_test:
         name: Build & Test
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
@@ -15,14 +14,14 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                node-version: [15, 16]
+                node-version: [15, 16, 18, 20]
 
         steps:
             -
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
             -
                 name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v3
                 with:
                     node-version: ${{ matrix.node-version }}
             -
@@ -32,7 +31,7 @@ jobs:
                 name: Run Tests
                 run: npm test
                 env:
-                    APIFY_PROXY_PASSWORD: ${{ secrets.APIFY_PROXY_PASSWORD }}
+                    APIFY_PROXY_PASSWORD: ${{ secrets.APIFY_TEST_USER_PROXY_PASSWORD }}
 
     lint:
         name: Lint
@@ -40,10 +39,10 @@ jobs:
 
         steps:
             -
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
             -
                 name: Use Node.js 16
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v3
                 with:
                     node-version: 16
             -

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ jobs:
         runs-on: ${{ matrix.os }}
 
         strategy:
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
                 node-version: [15, 16, 18, 20]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ on:
     types: [ published ]
 
 jobs:
-  # NPM install is done in a separate job and cached to speed up the following jobs.
   build_and_test:
     name: Build & Test
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
@@ -19,14 +18,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [15, 16]
+        node-version: [15, 16, 18, 20]
 
     steps:
       -
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       -
@@ -36,7 +35,7 @@ jobs:
         name: Run Tests
         run: npm test
         env:
-          APIFY_PROXY_PASSWORD: ${{ secrets.APIFY_PROXY_PASSWORD }}
+          APIFY_PROXY_PASSWORD: ${{ secrets.APIFY_TEST_USER_PROXY_PASSWORD }}
 
   lint:
     name: Lint
@@ -44,10 +43,10 @@ jobs:
 
     steps:
       -
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       -
@@ -64,9 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
@@ -84,7 +83,9 @@ jobs:
         run: npm install
       -
         name: Publish to NPM
-        run: NODE_AUTH_TOKEN=${{secrets.NPM_TOKEN}} npm publish --tag ${{ env.RELEASE_TAG }} --access public
+        run: npm publish --tag ${{ env.RELEASE_TAG }} --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
       -
         # Latest version is tagged by the release process so we only tag beta here.
         name: Tag Version

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,7 +5,7 @@ export default async (): Promise<Config.InitialOptions> => ({
     preset: 'ts-jest',
     testEnvironment: 'node',
     testRunner: 'jest-circus/runner',
-    testTimeout: 20_000,
+    testTimeout: 40_000,
     collectCoverage: true,
     collectCoverageFrom: [
         '**/src/**/*.ts',

--- a/src/agent/wrapped-agent.ts
+++ b/src/agent/wrapped-agent.ts
@@ -68,4 +68,75 @@ export class WrappedAgent<T extends HttpAgent> implements HttpAgent {
     get requests(): HttpAgent['requests'] {
         return this.agent.requests;
     }
+
+    on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.agent.on(eventName, listener);
+        return this;
+    }
+
+    once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.agent.once(eventName, listener);
+        return this;
+    }
+
+    off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.agent.off(eventName, listener);
+        return this;
+    }
+
+    addListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.agent.addListener(eventName, listener);
+        return this;
+    }
+
+    removeListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.agent.removeListener(eventName, listener);
+        return this;
+    }
+
+    removeAllListeners(eventName?: string | symbol): this {
+        this.agent.removeAllListeners(eventName);
+        return this;
+    }
+
+    setMaxListeners(n: number): this {
+        this.agent.setMaxListeners(n);
+        return this;
+    }
+
+    getMaxListeners(): number {
+        return this.agent.getMaxListeners();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    listeners(eventName: string | symbol): Function[] {
+        return this.agent.listeners(eventName);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    rawListeners(eventName: string | symbol): Function[] {
+        return this.agent.rawListeners(eventName);
+    }
+
+    emit(eventName: string | symbol, ...args: any[]): boolean {
+        return this.agent.emit(eventName, ...args);
+    }
+
+    eventNames(): (string | symbol)[] {
+        return this.agent.eventNames();
+    }
+
+    listenerCount(eventName: string | symbol): number {
+        return this.agent.listenerCount(eventName);
+    }
+
+    prependListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.agent.prependListener(eventName, listener);
+        return this;
+    }
+
+    prependOnceListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.agent.prependOnceListener(eventName, listener);
+        return this;
+    }
 }

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -4,6 +4,8 @@ import getStream from 'get-stream';
 import { TransformHeadersAgent } from '../src/agent/transform-headers-agent';
 import { startDummyServer } from './helpers/dummy-server';
 
+const NODE_MAJOR_VERSION = parseInt(process.versions.node.split('.')[0], 10);
+
 const agent = new http.Agent({
     keepAlive: true,
 });
@@ -42,7 +44,11 @@ describe('TransformHeadersAgent', () => {
 
             expect(headers.Cookie).toBe(requestHeaders.cookie);
             expect(headers['User-Agent']).toBe(requestHeaders['user-agent']);
-            expect(headers.Connection).toBe('close');
+            if (NODE_MAJOR_VERSION >= 19) {
+                expect(headers.Connection).toBe('keep-alive');
+            } else {
+                expect(headers.Connection).toBe('close');
+            }
 
             done();
         });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -208,6 +208,8 @@ describe('GotScraping', () => {
     });
 
     describe('Integration', () => {
+        jest.retryTimes(3);
+
         // FIXME: this should be using a local server instead
         test.skip('should order headers', async () => {
             const { rawHeaders } = await gotScraping({ url: 'https://api.apify.com/v2/browser-info?rawHeaders=1' }).json<{ rawHeaders: string[] }>();


### PR DESCRIPTION
I've updated the GitHub workflows to use the new secrets synced from Doppler. And while I had this open, I've also updated the GitHub actions versions to get rid of the deprecation warnings, and I've added Node 18 and 20 to the test roster.