### PR TITLE
fix: proxies work correctly in Node v18.17

### DIFF
--- a/src/resolve-protocol.ts
+++ b/src/resolve-protocol.ts
@@ -31,8 +31,9 @@ const connect = async (proxyUrl: string, options: tls.ConnectionOptions, callbac
                 method: 'CONNECT',
                 headers,
                 path: host,
+                pathname: host,
                 rejectUnauthorized: false,
-            });
+            } as any);
 
             request.end();
 


### PR DESCRIPTION
The way Node `v18.17` processes URLs causes that proxied connections are accessing `/` (pathname of the proxy), instead of the actual proxied URL. We could (should) eventually rewrite `got-scraping` so it uses the native `http2` instead of `http2-wrapper`, but this goal is a bit too far right now. 

Closes #97 