### PR TITLE
feat: add Cloudflare blocking benchmarking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "got-scraping",
-    "version": "3.2.16",
+    "version": "4.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "got-scraping",
-            "version": "3.2.16",
+            "version": "4.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "got": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
         "prepublishOnly": "npm run build",
         "lint": "eslint src test",
         "lint:fix": "eslint src test --fix",
-        "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage"
+        "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
+        "test-blocking": "ts-node -T ./test/live-testing/index.js"
     },
     "author": {
         "name": "Apify",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         "lint": "eslint src test",
         "lint:fix": "eslint src test --fix",
         "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
-        "test-blocking": "ts-node -T ./test/live-testing/index.js"
+        "pretest:blocking": "npm run build",
+        "test:blocking": "ts-node -T ./test/live-testing/index.js"
     },
     "author": {
         "name": "Apify",

--- a/test/live-testing/index.js
+++ b/test/live-testing/index.js
@@ -1,17 +1,16 @@
-import { readFileSync } from 'fs';
 import { setTimeout } from 'timers/promises';
-import { gotScraping } from '../../dist/index.js'; 
 import got from 'got';
+import { gotScraping } from '../../dist/index.js';
 
 async function processUrls(gotImplementation, urls) {
     let passed = 0;
     let blocked = 0;
     let failed = 0;
 
-    let url = null;
-    while (url = urls.shift()) {
+    let url = urls.shift();
+    while (url) {
         try {
-            //console.log(`crawling ${url}`);
+            // console.log(`crawling ${url}`);
             const request = gotImplementation.get(url);
 
             const result = await Promise.race([
@@ -24,7 +23,7 @@ async function processUrls(gotImplementation, urls) {
                 throw new Error('timeout');
             }
 
-            //console.log(`crawled ${url}`);
+            // console.log(`crawled ${url}`);
 
             if (result.body.includes('Just a moment...')) {
                 blocked++;
@@ -33,12 +32,13 @@ async function processUrls(gotImplementation, urls) {
             }
         } catch (e) {
             failed++;
-            //console.error(e.message);
-            continue;
+            // console.error(e.message);
         }
+
+        url = urls.shift();
     }
 
-    //console.log('done!');
+    // console.log('done!');
     return { passed, blocked, failed };
 }
 
@@ -51,11 +51,11 @@ async function runInParallel(implementation, urls) {
         acc.blocked += blocked;
         acc.failed += failed;
         return acc;
-    }, {passed: 0, blocked: 0, failed: 0});
+    }, { passed: 0, blocked: 0, failed: 0 });
 }
 
 (async () => {
-    const { body } = await got.get('https://raw.githubusercontent.com/apify/fingerprint-suite/master/test/antibot-services/live-testing/cloudflare-websites.csv')
+    const { body } = await got.get('https://raw.githubusercontent.com/apify/fingerprint-suite/master/test/antibot-services/live-testing/cloudflare-websites.csv');
     const urls = body.split('\n');
 
     const [gotScrapingResults, gotResults] = await Promise.all([

--- a/test/live-testing/index.js
+++ b/test/live-testing/index.js
@@ -1,0 +1,74 @@
+import { readFileSync } from 'fs';
+import { setTimeout } from 'timers/promises';
+import { gotScraping } from '../../dist/index.js'; 
+import got from 'got';
+
+async function processUrls(gotImplementation, urls) {
+    let passed = 0;
+    let blocked = 0;
+    let failed = 0;
+
+    let url = null;
+    while (url = urls.shift()) {
+        try {
+            //console.log(`crawling ${url}`);
+            const request = gotImplementation.get(url);
+
+            const result = await Promise.race([
+                request,
+                setTimeout(5000),
+            ]);
+
+            if (!result?.body) {
+                request.cancel();
+                throw new Error('timeout');
+            }
+
+            //console.log(`crawled ${url}`);
+
+            if (result.body.includes('Just a moment...')) {
+                blocked++;
+            } else {
+                passed++;
+            }
+        } catch (e) {
+            failed++;
+            //console.error(e.message);
+            continue;
+        }
+    }
+
+    //console.log('done!');
+    return { passed, blocked, failed };
+}
+
+async function runInParallel(implementation, urls) {
+    const localUrls = [...urls];
+    const partialResults = await Promise.all(Array.from({ length: 5 }, () => processUrls(implementation, localUrls)));
+
+    return partialResults.reduce((acc, { passed, blocked, failed }) => {
+        acc.passed += passed;
+        acc.blocked += blocked;
+        acc.failed += failed;
+        return acc;
+    }, {passed: 0, blocked: 0, failed: 0});
+}
+
+(async () => {
+    const { body } = await got.get('https://raw.githubusercontent.com/apify/fingerprint-suite/master/test/antibot-services/live-testing/cloudflare-websites.csv')
+    const urls = body.split('\n');
+
+    const [gotScrapingResults, gotResults] = await Promise.all([
+        runInParallel(gotScraping, urls),
+        runInParallel(got, urls),
+    ]);
+
+    console.log('got-scraping');
+    console.log(gotScrapingResults);
+
+    console.log('---');
+    console.log('got');
+    console.log(gotResults);
+
+    process.exit(0);
+})();


### PR DESCRIPTION
Port of the `fingerprint-suite` benchmark for comparing the anti-blocking capabilities of different got versions (`got` vs `got-scraping`).

A quick run shows that the ESM port didn't mess up the antiblocking features in any way, here are the results:

```text
got-scraping@latest (3.2.15)
{ passed: 103, blocked: 21, failed: 15 }
---
got-scraping@4.0.0
{ passed: 103, blocked: 20, failed: 16 }
---
got@13.0.0
{ passed: 69, blocked: 0, failed: 70 }
```

@B4nan , @vladfrangu I suppose there is nothing else blocking the release of `got-scraping@4.0.0` then? :)