### PR TITLE
fix: process http over https proxy correctly

### DIFF
--- a/src/hooks/proxy.ts
+++ b/src/hooks/proxy.ts
@@ -1,7 +1,7 @@
 import { Options, type Agents } from 'got';
 import http2, { auto } from 'http2-wrapper';
 import { URL } from 'node:url';
-import { HttpRegularProxyAgent, HttpsProxyAgent } from '../agent/h1-proxy-agent.js';
+import { HttpProxyAgent, HttpRegularProxyAgent, HttpsProxyAgent } from '../agent/h1-proxy-agent.js';
 import { TransformHeadersAgent } from '../agent/transform-headers-agent.js';
 
 const {
@@ -87,7 +87,7 @@ async function getAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean) {
         } else {
             // Upstream proxies hang up connections on CONNECT + unsecure HTTP
             agent = {
-                http: new TransformHeadersAgent(new HttpRegularProxyAgent(nativeOptions)),
+                http: new TransformHeadersAgent(new HttpProxyAgent(nativeOptions)),
                 https: new TransformHeadersAgent(new HttpsProxyAgent(nativeOptions)),
                 http2: new Http2OverHttps(wrapperOptions),
             };

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -4,6 +4,7 @@ import { jest } from '@jest/globals';
 import {
     HttpsProxyAgent,
     HttpRegularProxyAgent,
+    HttpProxyAgent,
 } from '../src/agent/h1-proxy-agent.js';
 
 import { proxyHook } from '../src/hooks/proxy.js';
@@ -96,7 +97,7 @@ describe('Proxy', () => {
 
             const { agent } = options;
             expect(agent.http).toBeInstanceOf(TransformHeadersAgent);
-            expect((agent.http as any).agent).toBeInstanceOf(HttpRegularProxyAgent);
+            expect((agent.http as any).agent).toBeInstanceOf(HttpProxyAgent);
         });
 
         test('should support https request over https proxy', async () => {


### PR DESCRIPTION
Previously, HTTP request (`http://example.com/resource`) over HTTPS proxy (`https://proxy.com`) was sent as:
- HTTP GET -> `https://proxy.com/example.com/resource`.
  - this causes errors, as we're sending an HTTP request to an HTTPS proxy.

After a discussion with @jirimoravcik , we figured that the "pathname" proxies are a marginal thing (`CONNECT` is more popular nowadays).

This PR fixes that - `got-scraping` now does:
- HTTPS CONNECT -> `https://proxy.com/` -> HTTP GET `http://example.com/resource`.

 Yet, there is still this comment:
`// Upstream proxies hang up connections on CONNECT + unsecure HTTP`
maybe @szmarczak knows what that was supposed to mean? 😅 seems dangerously close to what we want to do now.

---

Fixes #126 