### PR TITLE
fix: pass the timeout to the `resolveProtocol` calls

### DIFF
--- a/src/hooks/browser-headers.ts
+++ b/src/hooks/browser-headers.ts
@@ -39,10 +39,13 @@ const getResolveProtocolFunction = (options: Options, proxyUrl: string | undefin
     }
 
     if (proxyUrl) {
-        return createResolveProtocol(proxyUrl, sessionData as any);
+        return createResolveProtocol(proxyUrl, sessionData as any, options?.timeout?.connect ?? options?.timeout?.request);
     }
 
-    return http2.auto.resolveProtocol;
+    return (...args: Parameters<typeof http2.auto.resolveProtocol>) => http2.auto.resolveProtocol({
+        ...args[0],
+        timeout: options?.timeout?.connect ?? options?.timeout?.request,
+    });
 };
 
 export async function browserHeadersHook(options: Options): Promise<void> {

--- a/src/hooks/browser-headers.ts
+++ b/src/hooks/browser-headers.ts
@@ -39,12 +39,12 @@ const getResolveProtocolFunction = (options: Options, proxyUrl: string | undefin
     }
 
     if (proxyUrl) {
-        return createResolveProtocol(proxyUrl, sessionData as any, options?.timeout?.connect ?? options?.timeout?.request);
+        return createResolveProtocol(proxyUrl, sessionData as any, Math.min(options?.timeout?.connect ?? 60_000, options?.timeout?.request ?? 60_000));
     }
 
     return (...args: Parameters<typeof http2.auto.resolveProtocol>) => http2.auto.resolveProtocol({
         ...args[0],
-        timeout: options?.timeout?.connect ?? options?.timeout?.request,
+        timeout: Math.min(options?.timeout?.connect ?? 60_000, options?.timeout?.request ?? 60_000),
     });
 };
 

--- a/src/hooks/http2.ts
+++ b/src/hooks/http2.ts
@@ -11,7 +11,11 @@ export function http2Hook(options: Options): void {
         options.request = (url, requestOptions, callback) => {
             const typedRequestOptions = requestOptions as AutoRequestOptions;
             if (proxyUrl) {
-                typedRequestOptions.resolveProtocol = createResolveProtocol(proxyUrl, sessionData as any);
+                typedRequestOptions.resolveProtocol = createResolveProtocol(
+                    proxyUrl,
+                    sessionData as any,
+                    options?.timeout?.connect ?? options?.timeout?.request,
+                );
             }
 
             return auto(url, typedRequestOptions, callback);

--- a/src/hooks/http2.ts
+++ b/src/hooks/http2.ts
@@ -14,7 +14,7 @@ export function http2Hook(options: Options): void {
                 typedRequestOptions.resolveProtocol = createResolveProtocol(
                     proxyUrl,
                     sessionData as any,
-                    options?.timeout?.connect ?? options?.timeout?.request,
+                    Math.min(options?.timeout?.connect ?? 60_000, options?.timeout?.request ?? 60_000),
                 );
             }
 

--- a/src/resolve-protocol.ts
+++ b/src/resolve-protocol.ts
@@ -73,7 +73,7 @@ export interface ProtocolCache {
     resolveAlpnQueue?: typeof defaults.resolveAlpnQueue;
 }
 
-export const createResolveProtocol = (proxyUrl: string, sessionData?: ProtocolCache): ResolveProtocolFunction => {
+export const createResolveProtocol = (proxyUrl: string, sessionData?: ProtocolCache, timeout?: number): ResolveProtocolFunction => {
     let { protocolCache, resolveAlpnQueue } = defaults;
 
     if (sessionData) {
@@ -89,9 +89,14 @@ export const createResolveProtocol = (proxyUrl: string, sessionData?: ProtocolCa
         return connect(proxyUrl, pOptions, pCallback);
     };
 
-    return auto.createResolveProtocol(
+    const resolveProtocol: ResolveProtocolFunction = auto.createResolveProtocol(
         protocolCache as unknown as Map<string, string>,
         resolveAlpnQueue,
         connectWithProxy,
     );
+
+    return async (...args: Parameters<ResolveProtocolFunction>) => resolveProtocol({
+        ...args[0],
+        timeout,
+    });
 };


### PR DESCRIPTION
ALPN negotiation with an unresponsive server caused prolonged hangs, as it didn't respect the specified timeouts.

Fixes #130 