### PR TITLE
fix: consistent proxy auth handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-4.0.6 / 2024/10/23
+4.0.7 / 2024/10/23
 ====================
 - Handles proxy authentication consistently throughout the codebase (solves e.g. this [`http2-wrapper`](https://github.com/szmarczak/http2-wrapper/issues/108) issue).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+4.0.6 / 2024/10/23
+====================
+- Handles proxy authentication consistently throughout the codebase (solves e.g. this [`http2-wrapper`](https://github.com/szmarczak/http2-wrapper/issues/108) issue).
+
 4.0.6 / 2024/05/22
 ====================
 - Logging `CONNECT` error response body instead of the length only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "got-scraping",
-    "version": "4.0.6",
+    "version": "4.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "got-scraping",
-            "version": "4.0.6",
+            "version": "4.0.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "got": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "got-scraping",
-    "version": "4.0.6",
+    "version": "4.0.7",
     "description": "HTTP client made for scraping based on got.",
     "engines": {
         "node": ">=16"

--- a/src/agent/h1-proxy-agent.ts
+++ b/src/agent/h1-proxy-agent.ts
@@ -4,7 +4,7 @@ import https from 'node:https';
 import { isIPv6 } from 'node:net';
 import tls, { type ConnectionOptions } from 'node:tls';
 import { URL } from 'node:url';
-import { getBasic } from '../auth.js';
+import { buildBasicAuthHeader } from '../auth.js';
 
 interface AgentOptions extends http.AgentOptions {
     proxy: string | URL;
@@ -63,7 +63,7 @@ export class HttpRegularProxyAgent extends http.Agent {
 
         request.path = url.href;
 
-        const basic = getBasic(this.proxy);
+        const basic = buildBasicAuthHeader(this.proxy);
         if (basic) {
             request.setHeader('proxy-authorization', basic);
         }
@@ -101,7 +101,7 @@ export class HttpProxyAgent extends http.Agent {
             host: hostport,
         };
 
-        const basic = getBasic(this.proxy);
+        const basic = buildBasicAuthHeader(this.proxy);
         if (basic) {
             headers['proxy-authorization'] = basic;
             headers.authorization = basic;

--- a/src/agent/h1-proxy-agent.ts
+++ b/src/agent/h1-proxy-agent.ts
@@ -4,6 +4,7 @@ import https from 'node:https';
 import { isIPv6 } from 'node:net';
 import tls, { type ConnectionOptions } from 'node:tls';
 import { URL } from 'node:url';
+import { getBasic } from '../auth.js';
 
 interface AgentOptions extends http.AgentOptions {
     proxy: string | URL;
@@ -28,20 +29,6 @@ const getPort = (url: URL): number => {
     }
 
     throw new Error(`Unexpected protocol: ${url.protocol}`);
-};
-
-const getBasic = (url: URL): string => {
-    let basic = '';
-    if (url.username || url.password) {
-        const username = decodeURIComponent(url.username);
-        const password = decodeURIComponent(url.password);
-
-        basic = Buffer.from(`${username}:${password}`).toString('base64');
-
-        return `Basic ${basic}`;
-    }
-
-    return basic;
 };
 
 export class HttpRegularProxyAgent extends http.Agent {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,7 @@
  * @param url URL object to process
  * @returns `Basic BASE64` string
  */
-export function getBasic(url: URL): string | null {
+export function buildBasicAuthHeader(url: URL): string | null {
     if (!url.username && !url.password) {
         return null;
     }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,8 +9,8 @@ export function getBasic(url: URL): string | null {
         return null;
     }
 
-    const username = decodeURIComponent(url.username);
-    const password = decodeURIComponent(url.password);
+    const username = decodeURIComponent(url.username ?? '');
+    const password = decodeURIComponent(url.password ?? '');
 
     const basic = Buffer.from(`${username}:${password}`).toString('base64');
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns the Basic auth string based on the `username` and `password` parts of the given URL.
+ * If the URL does not contain neither username nor password, returns `null`.
+ * @param url URL object to process
+ * @returns `Basic BASE64` string
+ */
+export function getBasic(url: URL): string | null {
+    if (!url.username && !url.password) {
+        return null;
+    }
+
+    const username = decodeURIComponent(url.username);
+    const password = decodeURIComponent(url.password);
+
+    const basic = Buffer.from(`${username}:${password}`).toString('base64');
+
+    return `Basic ${basic}`;
+}

--- a/src/hooks/proxy.ts
+++ b/src/hooks/proxy.ts
@@ -3,6 +3,7 @@ import http2, { auto } from 'http2-wrapper';
 import { URL } from 'node:url';
 import { HttpProxyAgent, HttpRegularProxyAgent, HttpsProxyAgent } from '../agent/h1-proxy-agent.js';
 import { TransformHeadersAgent } from '../agent/transform-headers-agent.js';
+import { getBasic } from '../auth.js';
 
 const {
     HttpOverHttp2,
@@ -37,10 +38,19 @@ function validateProxyProtocol(protocol: string) {
 async function getAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean) {
     // Sockets must not be reused, the proxy server may rotate upstream proxies as well.
 
+    const headers: Record<string, string> = {};
+    const basic = getBasic(parsedProxyUrl);
+
+    if (basic) {
+        headers.authorization = basic;
+        headers['proxy-authorization'] = basic;
+    }
+
     // `http2-wrapper` Agent options
     const wrapperOptions = {
         proxyOptions: {
             url: parsedProxyUrl,
+            headers,
 
             // Based on the got https.rejectUnauthorized option
             rejectUnauthorized,

--- a/src/hooks/proxy.ts
+++ b/src/hooks/proxy.ts
@@ -3,7 +3,7 @@ import http2, { auto } from 'http2-wrapper';
 import { URL } from 'node:url';
 import { HttpProxyAgent, HttpRegularProxyAgent, HttpsProxyAgent } from '../agent/h1-proxy-agent.js';
 import { TransformHeadersAgent } from '../agent/transform-headers-agent.js';
-import { getBasic } from '../auth.js';
+import { buildBasicAuthHeader } from '../auth.js';
 
 const {
     HttpOverHttp2,
@@ -39,7 +39,7 @@ async function getAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean) {
     // Sockets must not be reused, the proxy server may rotate upstream proxies as well.
 
     const headers: Record<string, string> = {};
-    const basic = getBasic(parsedProxyUrl);
+    const basic = buildBasicAuthHeader(parsedProxyUrl);
 
     if (basic) {
         headers.authorization = basic;

--- a/src/resolve-protocol.ts
+++ b/src/resolve-protocol.ts
@@ -5,6 +5,7 @@ import { type Headers } from 'got';
 import { auto, type ResolveProtocolConnectFunction, type ResolveProtocolFunction } from 'http2-wrapper';
 import QuickLRU from 'quick-lru';
 import { ProxyError } from './hooks/proxy.js';
+import { getBasic } from './auth.js';
 
 const connect = async (proxyUrl: string, options: tls.ConnectionOptions, callback: () => void) => new Promise<TLSSocket>((resolve, reject) => {
     let host = `${options.host}:${options.port}`;
@@ -20,12 +21,11 @@ const connect = async (proxyUrl: string, options: tls.ConnectionOptions, callbac
             };
 
             const url = new URL(proxyUrl);
-            const username = decodeURIComponent(url.username);
-            const password = decodeURIComponent(url.password);
+            const basic = getBasic(url);
 
-            if (username || password) {
-                headers.authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
-                headers['proxy-authorization'] = headers.authorization;
+            if (basic) {
+                headers.authorization = basic;
+                headers['proxy-authorization'] = basic;
             }
 
             const request = await auto(url, {

--- a/src/resolve-protocol.ts
+++ b/src/resolve-protocol.ts
@@ -5,7 +5,7 @@ import { type Headers } from 'got';
 import { auto, type ResolveProtocolConnectFunction, type ResolveProtocolFunction } from 'http2-wrapper';
 import QuickLRU from 'quick-lru';
 import { ProxyError } from './hooks/proxy.js';
-import { getBasic } from './auth.js';
+import { buildBasicAuthHeader } from './auth.js';
 
 const connect = async (proxyUrl: string, options: tls.ConnectionOptions, callback: () => void) => new Promise<TLSSocket>((resolve, reject) => {
     let host = `${options.host}:${options.port}`;
@@ -21,7 +21,7 @@ const connect = async (proxyUrl: string, options: tls.ConnectionOptions, callbac
             };
 
             const url = new URL(proxyUrl);
-            const basic = getBasic(url);
+            const basic = buildBasicAuthHeader(url);
 
             if (basic) {
                 headers.authorization = basic;


### PR DESCRIPTION
Extracts and reuses the `getBasic` helper function. 

Uses this helper to generate the `Basic` authentication header in the `proxy` hooks (before, this was done further down the line by [`http2-wrapper`](https://github.com/szmarczak/http2-wrapper), see the [related issue](https://github.com/szmarczak/http2-wrapper/issues/108)).