### PR TITLE
fix: no Brotli decompression on an empty `HEAD` response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "got-scraping",
-    "version": "4.0.7",
+    "version": "4.0.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "got-scraping",
-            "version": "4.0.7",
+            "version": "4.0.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "got": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "got-scraping",
-    "version": "4.0.7",
+    "version": "4.0.8",
     "description": "HTTP client made for scraping based on got.",
     "engines": {
         "node": ">=16"

--- a/src/hooks/fix-decompress.ts
+++ b/src/hooks/fix-decompress.ts
@@ -56,7 +56,22 @@ const onResponse = (response: IncomingMessage, propagate: (fixedResponse: Incomi
             }
         });
     } else if (encoding === 'br') {
-        useDecompressor(zlib.createBrotliDecompress());
+        let read = false;
+
+        response.once('data', (chunk: Buffer) => {
+            read = true;
+
+            response.unshift(chunk);
+
+            const decompressor = zlib.createBrotliDecompress();
+            useDecompressor(decompressor);
+        });
+
+        response.once('end', () => {
+            if (!read) {
+                propagate(response);
+            }
+        });
     } else {
         propagate(response);
     }


### PR DESCRIPTION
Closes #149 