### PR TITLE
expose getAgents

### DIFF
--- a/src/hooks/proxy.ts
+++ b/src/hooks/proxy.ts
@@ -35,7 +35,7 @@ function validateProxyProtocol(protocol: string) {
     }
 }
 
-async function getAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean) {
+export async function getAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean) {
     // Sockets must not be reused, the proxy server may rotate upstream proxies as well.
 
     const headers: Record<string, string> = {};


### PR DESCRIPTION
Hello,

Can `getAgents` be exposed? It's useful to setup `agent` out of the hook 🙂