### PR TITLE
chore(ci): test against Node 22, update GH Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,10 +42,10 @@ jobs:
             -
                 uses: actions/checkout@v4
             -
-                name: Use Node.js 20
+                name: Use Node.js 22
                 uses: actions/setup-node@v4
                 with:
-                    node-version: 20
+                    node-version: 22
             -
                 run: npm install
             -

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,14 +15,14 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                node-version: [18, 20]
+                node-version: [18, 20, 22]
 
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
             -
                 name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v3
+                uses: actions/setup-node@v4
                 with:
                     node-version: ${{ matrix.node-version }}
             -
@@ -40,10 +40,10 @@ jobs:
 
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
             -
                 name: Use Node.js 20
-                uses: actions/setup-node@v3
+                uses: actions/setup-node@v4
                 with:
                     node-version: 20
             -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
 
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       -
@@ -43,12 +43,12 @@ jobs:
 
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
-        name: Use Node.js 20
-        uses: actions/setup-node@v3
+        name: Use Node.js 22
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       -
         run: npm install
       -
@@ -63,11 +63,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       -
         # Determine if this is a beta or latest release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "got-scraping",
-    "version": "4.0.8",
+    "version": "4.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "got-scraping",
-            "version": "4.0.8",
+            "version": "4.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "got": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "got-scraping",
-    "version": "4.0.8",
+    "version": "4.1.0",
     "description": "HTTP client made for scraping based on got.",
     "engines": {
         "node": ">=16"


### PR DESCRIPTION
Uses Node 22 in CI for build and testing purposes as discussed under #152 . Updates third-party GitHub Actions to their latest versions. 

Bumps the package version to `4.1.0` to fix the prerelease publish for #151 .