### PR TITLE
fix: export getAgents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ setupDecodeURI();
 
 export * from 'got';
 export { gotScraping, TransformHeadersAgent };
+export { getAgents } from './hooks/proxy.js';
 
 export const hooks = {
     init,


### PR DESCRIPTION
In my previous PR, I planned to load this helper from filesystem but I didn't take into account the way the library is bundled is reducing all the code into a single file.

This PR makes possible to just do `import { getAgents } from 'got-scraping')`