### PR TITLE
chore: bump package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "got-scraping",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "got-scraping",
-            "version": "4.1.0",
+            "version": "4.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "got": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "got-scraping",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "HTTP client made for scraping based on got.",
     "engines": {
         "node": ">=16"


### PR DESCRIPTION
Enable automatic prerelease from CI by bumping the package version in `package.json`.