### PR TITLE
chore: new `@types/node` version compatibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
 	},
 	"rules": {
 		"@typescript-eslint/no-explicit-any": "off",
-		"no-void": "off"
+		"no-void": "off",
+		"@typescript-eslint/ban-ts-comment": "warn"
 	}
  }

--- a/src/agent/h1-proxy-agent.ts
+++ b/src/agent/h1-proxy-agent.ts
@@ -79,9 +79,11 @@ export class HttpProxyAgent extends http.Agent {
     constructor(options: AgentOptions) {
         super(options);
 
+        // @ts-ignore New @types/node patch has narrower types than got-scraping exported interfaces
         initialize(this, options);
     }
 
+    // @ts-ignore New @types/node patch has narrower types than got-scraping exported interfaces
     createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
         if (options.path) {
             // @ts-expect-error @types/node is missing types
@@ -150,9 +152,11 @@ export class HttpsProxyAgent extends https.Agent {
     constructor(options: AgentOptions) {
         super(options);
 
+        // @ts-ignore New @types/node patch has narrower types than got-scraping exported interfaces
         initialize(this, options);
     }
 
+    // @ts-ignore New @types/node patch has narrower types than got-scraping exported interfaces
     createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
         HttpProxyAgent.prototype.createConnection.call(this, options, callback);
     }

--- a/src/agent/wrapped-agent.ts
+++ b/src/agent/wrapped-agent.ts
@@ -1,4 +1,6 @@
+import type { NetConnectOpts } from 'net';
 import { ClientRequest, Agent as HttpAgent, type AgentOptions, type ClientRequestArgs } from 'node:http';
+import type { Duplex } from 'stream';
 
 /**
  * @see https://github.com/nodejs/node/blob/533cafcf7e3ab72e98a2478bc69aedfdf06d3a5e/lib/_http_client.js#L129-L162
@@ -138,5 +140,25 @@ export class WrappedAgent<T extends HttpAgent> implements HttpAgent {
     prependOnceListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
         this.agent.prependOnceListener(eventName, listener);
         return this;
+    }
+
+    createConnection(options: NetConnectOpts, callback?: (err: Error | null, stream: Duplex) => void): Duplex {
+        // @ts-ignore @types/node might have incorrect types
+        return this.agent.createConnection(options, callback);
+    }
+
+    keepSocketAlive(socket: Duplex): void {
+        // @ts-ignore @types/node might have incorrect types
+        this.agent.keepSocketAlive(socket);
+    }
+
+    reuseSocket(socket: Duplex, request: ClientRequest): void {
+        // @ts-ignore @types/node might have incorrect types
+        this.agent.reuseSocket(socket, request);
+    }
+
+    getName(options?: any): string {
+        // @ts-ignore @types/node might have incorrect types
+        return this.agent.getName(options);
     }
 }

--- a/src/hooks/proxy.ts
+++ b/src/hooks/proxy.ts
@@ -99,7 +99,9 @@ export async function getAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean
         } else {
             // Upstream proxies hang up connections on CONNECT + unsecure HTTP
             agent = {
+                // @ts-ignore New @types/node patch has narrower types than got-scraping exported interfaces
                 http: new TransformHeadersAgent(new HttpProxyAgent(nativeOptions)),
+                // @ts-ignore New @types/node patch has narrower types than got-scraping exported interfaces
                 https: new TransformHeadersAgent(new HttpsProxyAgent(nativeOptions)),
                 http2: new Http2OverHttps(wrapperOptions),
             };
@@ -108,6 +110,7 @@ export async function getAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean
         // Upstream proxies hang up connections on CONNECT + unsecure HTTP
         agent = {
             http: new TransformHeadersAgent(new HttpRegularProxyAgent(nativeOptions)),
+            // @ts-ignore New @types/node patch has narrower types than got-scraping exported interfaces
             https: new TransformHeadersAgent(new HttpsProxyAgent(nativeOptions)),
             http2: new Http2OverHttp(wrapperOptions),
         };


### PR DESCRIPTION
Caused by a recent update of `@types/node` (see here https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73095). By implementing the missing methods (and wrapping other calls in `@ts-ignore`), this should fix the downstream build errors (e.g. [here](https://github.com/apify/crawlee/actions/runs/15988466886/job/45097154759#step:12:156))

Closes #163 