### PR TITLE
fix: cjs import

### DIFF
--- a/src/hooks/http2.ts
+++ b/src/hooks/http2.ts
@@ -1,10 +1,10 @@
 import { URL } from 'node:url';
 import { Options } from 'got';
 import http2Wrapper, { type AutoRequestOptions } from 'http2-wrapper';
-
-const { auto } = http2Wrapper;
 import type { Context } from '../context.js';
 import { createResolveProtocol } from '../resolve-protocol.js';
+
+const { auto } = http2Wrapper;
 
 export function http2Hook(options: Options): void {
     const { proxyUrl, sessionData } = options.context as Context;

--- a/src/hooks/http2.ts
+++ b/src/hooks/http2.ts
@@ -1,6 +1,8 @@
 import { URL } from 'node:url';
 import { Options } from 'got';
-import { auto, type AutoRequestOptions } from 'http2-wrapper';
+import http2Wrapper, { type AutoRequestOptions } from 'http2-wrapper';
+
+const { auto } = http2Wrapper;
 import type { Context } from '../context.js';
 import { createResolveProtocol } from '../resolve-protocol.js';
 

--- a/src/hooks/proxy.ts
+++ b/src/hooks/proxy.ts
@@ -1,12 +1,12 @@
 import { Options, type Agents } from 'got';
 import http2Wrapper from 'http2-wrapper';
-
-const http2 = http2Wrapper;
-const { auto } = http2Wrapper;
 import { URL } from 'node:url';
 import { HttpProxyAgent, HttpRegularProxyAgent, HttpsProxyAgent } from '../agent/h1-proxy-agent.js';
 import { TransformHeadersAgent } from '../agent/transform-headers-agent.js';
 import { buildBasicAuthHeader } from '../auth.js';
+
+const http2 = http2Wrapper;
+const { auto } = http2Wrapper;
 
 const {
     HttpOverHttp2,

--- a/src/hooks/proxy.ts
+++ b/src/hooks/proxy.ts
@@ -1,5 +1,8 @@
 import { Options, type Agents } from 'got';
-import http2, { auto } from 'http2-wrapper';
+import http2Wrapper from 'http2-wrapper';
+
+const http2 = http2Wrapper;
+const { auto } = http2Wrapper;
 import { URL } from 'node:url';
 import { HttpProxyAgent, HttpRegularProxyAgent, HttpsProxyAgent } from '../agent/h1-proxy-agent.js';
 import { TransformHeadersAgent } from '../agent/transform-headers-agent.js';

--- a/src/resolve-protocol.ts
+++ b/src/resolve-protocol.ts
@@ -4,11 +4,11 @@ import tls, { TLSSocket } from 'node:tls';
 import { URL } from 'node:url';
 import { type Headers } from 'got';
 import http2Wrapper, { type ResolveProtocolConnectFunction, type ResolveProtocolFunction } from 'http2-wrapper';
-
-const { auto } = http2Wrapper;
 import QuickLRU from 'quick-lru';
 import { ProxyError } from './hooks/proxy.js';
 import { buildBasicAuthHeader } from './auth.js';
+
+const { auto } = http2Wrapper;
 
 const connect = async (proxyUrl: string, options: tls.ConnectionOptions, callback: () => void) => new Promise<TLSSocket>((resolve, reject) => {
     let host = `${options.host}:${options.port}`;

--- a/src/resolve-protocol.ts
+++ b/src/resolve-protocol.ts
@@ -3,7 +3,9 @@ import { isIPv6 } from 'node:net';
 import tls, { TLSSocket } from 'node:tls';
 import { URL } from 'node:url';
 import { type Headers } from 'got';
-import { auto, type ResolveProtocolConnectFunction, type ResolveProtocolFunction } from 'http2-wrapper';
+import http2Wrapper, { type ResolveProtocolConnectFunction, type ResolveProtocolFunction } from 'http2-wrapper';
+
+const { auto } = http2Wrapper;
 import QuickLRU from 'quick-lru';
 import { ProxyError } from './hooks/proxy.js';
 import { buildBasicAuthHeader } from './auth.js';


### PR DESCRIPTION
Hello,

This PR fixes ESM/CJS interop in got-scraping proxy hook by removing a named import from http2-wrapper (CommonJS).

Recently I got the following issue:

```txt
import http2, { auto } from "http2-wrapper";
^^^^
SyntaxError: Named export 'auto' not found. The requested module 'http2-wrapper' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:
import pkg from 'http2-wrapper';
const { auto } = pkg;
at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)
at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)
at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)
```

That's because `http2-wrapper` is a CommonJS package. Named ESM imports from CJS `{ auto }` are not guaranteed and can fail depending on runtime/module interop behavior. Accessing auto from the default import is the stable cross-runtime approach.