### PR TITLE
ci: Disable testing on Node.js 18

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                node-version: [18, 20, 22, 24]
+                node-version: [20, 22, 24]
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18, 20, 22, 24]
+        node-version: [20, 22, 24]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We've [decided](https://github.com/apify/got-scraping/pull/177#pullrequestreview-4308001671) to disable Node.js 18 tests, as PNPM doesn't work well with it in CI. Both Node.js 18 and got-scraping are is EOL anyway, and noone should use them, so it doesn't matter much.